### PR TITLE
Update all dependencies to current installed versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,17 +18,18 @@ keywords = ["Data Engineering", "Data Pipelines", "SaaS", "Data", "Analytics Eng
 
 
 dependencies = [
-    "duckdb>=0.8.1",
-    "minio>=7.1.0",
-    "pandas>=2.0.0",
-    "faker>=18.0.0",
-    "dbt-core>=1.5.0",
-    "dbt-duckdb>=1.5.0",
-    "python-dotenv>=1.0.0",
+    "duckdb>=1.4.4",
+    "minio>=7.2.20",
+    "pandas>=3.0.1",
+    "faker>=40.8.0",
+    "dbt-core>=1.11.7",
+    "dbt-duckdb>=1.10.1",
+    "python-dotenv>=1.2.2",
     "user-agents>=2.2.0",
-    "plotly>=6.0.0",
-    "dash>=2.18.0",
-    "dash-bootstrap-components>=1.6.0",
+    "plotly>=6.6.0",
+    "dash>=4.0.0",
+    "dash-bootstrap-components>=2.0.4",
+    "mashumaro>=3.14",
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,55 +1,53 @@
 #===========================================================================
-# Use pyproject.toml to install dependencies for both the main pipeline and 
-# the analytics queries. 
+# Use pyproject.toml to install dependencies for both the main pipeline and
+# the analytics queries.
 
-# If using a virtual environment or your global environment, 
+# If using a virtual environment or your global environment,
 # pyproject.toml can be ran with the following command:
 
-# pip install -e . 
+# pip install -e .
 
 #===========================================================================
-# requirements.txt is used for the streamlit app. 
-# Streamlit will detect this file upon building its environment.
+# requirements.txt is used for the Dash app.
+# Install with:
 
-# If it doesn't, please navigate to the folder's destination in terminal. 
-# Then, run the following:
-
-# pip install -r requirements.txt 
+# pip install -r requirements.txt
 #===========================================================================
 
 
-# Core data handling 
-pandas>=2.1.3
-numpy>=1.26.2
+# Core data handling
+pandas>=3.0.1
+numpy>=2.4.2
 
 # Data formatting and storage
-duckdb>=1.1.2
-minio>=7.2.14
-pyarrow>=18.1.0  # Required for parquet support
-fastparquet>=2024.11.0
-dbt-duckdb>=1.9.1
-dbt-adapters>=1.13.2
-dbt-common>=1.14.0
-dbt-core>=1.9.1
-dbt-extractor>=0.5.1
-dbt-semantic-interfaces>=0.7.4
+duckdb>=1.4.4
+minio>=7.2.20
+pyarrow>=23.0.1
+fastparquet>=2025.12.0
+dbt-duckdb>=1.10.1
+dbt-adapters>=1.22.8
+dbt-common>=1.37.3
+dbt-core>=1.11.7
+dbt-extractor>=0.6.0
+dbt-semantic-interfaces>=0.9.0
+# 3.13 introduced a self-referential regression in JSONObjectSchema;
+# 3.14 may resolve it — if dbt deps still fails, pin to mashumaro==3.12.1
+mashumaro>=3.14
 
 # Data Visualization and Portfolio App
-plotly>=6.0.0
-dash>=2.18.0
-dash-bootstrap-components>=1.6.0
+plotly>=6.6.0
+dash>=4.0.0
+dash-bootstrap-components>=2.0.4
 
-# Data generation 
-Faker>=25.3.0
+# Data generation
+Faker>=40.8.0
 user-agents>=2.2.0
 
-# Logging 
-python-dotenv>=1.0.1
-pathlib>=1.0.1
+# Logging
+python-dotenv>=1.2.2
 
 # Date & time handling
-python-dateutil>=2.8.2
-datetime>=5.4
+python-dateutil>=2.9.0
 
 # Optional: Development dependencies
 # pytest>=7.0.0  # For testing


### PR DESCRIPTION
Bumps all packages to their latest resolved versions:
- pandas 2.x → 3.0.1
- numpy 1.x → 2.4.2
- duckdb 1.1.2 → 1.4.4
- minio 7.2.14 → 7.2.20
- pyarrow 18.x → 23.0.1
- fastparquet 2024.x → 2025.12.0
- dbt-core 1.9.1 → 1.11.7
- dbt-duckdb 1.9.1 → 1.10.1
- dbt-adapters 1.13.2 → 1.22.8
- dbt-common 1.14.0 → 1.37.3
- dbt-extractor 0.5.1 → 0.6.0
- dbt-semantic-interfaces 0.7.4 → 0.9.0
- mashumaro pinned <3.13 → >=3.14 (3.13 had a self-referential JSONObjectSchema regression; 3.14 targets the fix)
- plotly 6.0.0 → 6.6.0
- dash 2.18.0 → 4.0.0
- dash-bootstrap-components 1.6.0 → 2.0.4
- Faker 25.x → 40.8.0
- python-dotenv 1.0.1 → 1.2.2
- python-dateutil 2.8.2 → 2.9.0
- Removes pathlib and datetime from requirements (stdlib in Python 3.9+)

Note: Dash 4.0, dbc 2.0, and pandas 3.0 all contain breaking changes relative to the previous pinned versions — app.py and pipeline code may need updates if any deprecated APIs are in use.